### PR TITLE
Image Header - 64-bit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ be declared so that the header is placed in the correct location in the image.
 Otherwise, the linker would place the header in a indeterminent location that
 would be unqiue for every build. An example is provided below.
 ~~~
+extern uintptr_t __start;
 img_hdr_t image_hdr __attribute__((section(".image_hdr"))) = {
     .image_magic = IMAGE_MAGIC,
     .image_hdr_version = IMAGE_VERSION_CURRENT,
@@ -51,8 +52,9 @@ img_hdr_t image_hdr __attribute__((section(".image_hdr"))) = {
     .version_major = FW_VERSION_MAJOR,
     .version_minor = FW_VERSION_MINOR,
     .version_patch = FW_VERSION_PATCH,
-    .vector_addr = (uint32_t) &__start,
     .device_id = IMAGE_DEVICE_ID_HOST,
+    .vector_size = VECTOR_SIZE,
+    .vector_addr =  &__start,
     .git_dirty = GIT_DIRTY,
     .git_ahead = GIT_AHEAD,
     .git_sha = GIT_SHA,

--- a/include/image.h
+++ b/include/image.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 
 #define IMAGE_MAGIC (0xC0FE)
+#define VECTOR_SIZE (sizeof(uintptr_t))
 
 /**
  * @brief   Image Type Enumeration
@@ -82,9 +83,10 @@ typedef enum
  * version_major        Major version of the image.
  * version_minor        Minor version of the image.
  * version_patch        Patch version of the image.
- * vector_addr          Start address of where image expects to begin execution.
  * device_id            The identifier of the device that can execute this
  *                      image.
+ * vector_size          Size of the vector address field (4 for 32-bit; 8 for 64-bit).
+ * vector_addr          Start address of where image expects to begin execution.
  * git_dirty            Flag to indicate if commit that generated this build
  *                      is dirty.
  * git_ahead            Distance (in commits) that commit that generated this
@@ -102,8 +104,9 @@ typedef struct image_header_t
     uint8_t version_major;
     uint8_t version_minor;
     uint8_t version_patch;
-    uint32_t vector_addr;
     uint16_t device_id;
+    uint8_t vector_size;
+    uintptr_t vector_addr;
     uint8_t git_dirty;
     uint8_t git_ahead;
     char git_sha[8];


### PR DESCRIPTION
Fixes:
  - None

Features:
  - Image header now supports 64-bit architectures (#6)

NOTE: Image header version wasn't changed since Wavious has yet to ship any code using the image header.